### PR TITLE
Fix NULL deref in jalp_context_create()

### DIFF
--- a/src/producer_lib/src/jalp_context.c
+++ b/src/producer_lib/src/jalp_context.c
@@ -48,7 +48,13 @@
 
 jalp_context *jalp_context_create(void)
 {
-	jalp_context *context = jal_calloc(1, sizeof(*context));
+	jalp_context *context = NULL;
+
+	context = jal_calloc(1, sizeof(*context));
+	if (context == NULL) {
+		return NULL;
+	}
+
 	context->socket = -1;
 	return context;
 }


### PR DESCRIPTION
If jal_calloc() fails, then a NULL context would be derefenced when
setting the value of socket.

@jalop-tresys