### PR TITLE
jalp_audit: use audit_buffer_size when calling xmlReadMemory()

### DIFF
--- a/src/producer_lib/src/jalp_audit.c
+++ b/src/producer_lib/src/jalp_audit.c
@@ -71,7 +71,7 @@ enum jal_status jalp_audit(jalp_context *ctx,
 	// Only if schema validation is requested, expect that the
 	// input data is xml and attempt to parse into a document
 	if(JAF_VALIDATE_XML & flags) {
-		validated_doc = xmlReadMemory((const char *)audit_buffer, strlen((const char *)audit_buffer), "", NULL, 0);
+		validated_doc = xmlReadMemory((const char *)audit_buffer, audit_buffer_size, "", NULL, 0);
 		if(NULL == validated_doc) {
 			// If we expected XML and don't get XML, report a parse failure
 			status = JAL_E_XML_PARSE;


### PR DESCRIPTION
The buffer passed to jalp_audit() is an array of bytes and may not be a NUL-terminated C string.  The length of the buffer is known so it can be passed directly to xmlReadMemory() instead of trying to compute it.